### PR TITLE
Basic index page layout completed

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -1,0 +1,4 @@
+#iRule {
+    height:6px;
+    width:100%;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Get Informed</title>
+
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+
+    <script src='assets/scripts/script.js'></script>
+
+    <link rel="stylesheet" href="assets/style/style.css">
+
+
+
+</head>
+
+<body>
+
+    <div class='container' id='mainBootstrapContainer'>
+
+        <div class='row' id='topRow'>
+
+            <div class='col text-center' id='topCol'>
+
+                Top Column Where Search Boxes and Buttons Go
+
+            </div>
+
+        </div>
+
+        <div class="row bg-dark" id='iRule'></div>
+
+
+        <div class='row' id='dataRow'>
+
+            <div class='col text-center' id='NYTcol'>
+
+                Left Column Where NYT Headlines Go
+
+            </div>
+
+            <div class='col text-center' id='guardianCol'>
+
+                Right Column Where Guardian Headlines Go
+
+            </div>
+
+        </div>
+
+
+
+
+
+
+
+
+
+    </div>
+
+
+
+</body>
+
+</html>


### PR DESCRIPTION
Basic layout of the index page including top row for searching, and a second row with two columns: one for NYT headlines and one for Guardian headlines